### PR TITLE
Add Badges + FIWARE Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![FIWARE Third Party](https://nexus.lab.fiware.org/static/badges/chapters/third-party.svg)](https://www.fiware.org/developers/catalogue/)
 [![License: Apache](https://img.shields.io/github/license/yalewkidane/FIWARE_EPCIS_Mediation_Gateway.svg)](https://opensource.org/licenses/Apache-2.0)
+[![SOF support badge](https://nexus.lab.fiware.org/repository/raw/public/badges/stackoverflow/fiware.svg)](http://stackoverflow.com/questions/tagged/fiware)
 <br/>
 [![Documentation badge](https://img.shields.io/readthedocs/fiware-epcis-gateway.svg)](https://fiware-epcis-gateway.readthedocs.io/en/latest/?badge=latest)
 ![Status](https://nexus.lab.fiware.org/static/badges/statuses/incubating.svg)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 # Oliot-MG (FIWARE EPCIS Mediation Gateway)
 
+[![FIWARE Third Party](https://nexus.lab.fiware.org/static/badges/chapters/third-party.svg)](https://www.fiware.org/developers/catalogue/)
+[![License: Apache](https://img.shields.io/github/license/yalewkidane/FIWARE_EPCIS_Mediation_Gateway.svg)](https://opensource.org/licenses/Apache-2.0)
+<br/>
+[![Documentation badge](https://img.shields.io/readthedocs/fiware-epcis-gateway.svg)](https://fiware-epcis-gateway.readthedocs.io/en/latest/?badge=latest)
+![Status](https://nexus.lab.fiware.org/static/badges/statuses/incubating.svg)
 
- Oliot-MG is a mediation gateway which translates information from NGSI based IoT platform to EPCIS based IoT platform. This enables capturing state change in FIWARE context broker in the form of EPCIS Event. 
+ Oliot-MG is a mediation gateway which translates information from NGSI based IoT platform to EPCIS based IoT platform. This enables capturing state change in FIWARE context broker in the form of EPCIS Event.
 
 ![](./src/main/resources/static/FIware_EPCIS_Mediation_Gateway.png)
+
+This project is part of [FIWARE](https://www.fiware.org/). For more information check the FIWARE Catalogue entry for
+[Third Party Tools](https://github.com/Fiware/catalogue/tree/master/third-party).
+
+| :books: [Documentation](https://fiware-epcis-gateway.io) |
+| -------------------------------------------------------- |
 
 ## Contents
 
@@ -14,9 +25,9 @@
 
 
 ## Background
-To solve the issue of interoperability, multiple companies, organizations, and consortia have started to join and create standards. Currently, the two of the major standards that are widely being considered in the IoT sector are EPCIS and NGSI. Nevertheless, the two standards differ both in data encoding and service interface which create fragmentation from the point of view of data consumers application. Moreover, the two platforms differ in the underlying philosophy of representing and storing IoT data; namely, NGSI is entity-based and EPCIS is event-based. This creates an overhead to analyze and process data coming from the two platforms. 
+To solve the issue of interoperability, multiple companies, organizations, and consortia have started to join and create standards. Currently, the two of the major standards that are widely being considered in the IoT sector are EPCIS and NGSI. Nevertheless, the two standards differ both in data encoding and service interface which create fragmentation from the point of view of data consumers application. Moreover, the two platforms differ in the underlying philosophy of representing and storing IoT data; namely, NGSI is entity-based and EPCIS is event-based. This creates an overhead to analyze and process data coming from the two platforms.
 
-FIWARE - EPCIS mediation gateway is developed to solve the interoperability between NGSI and EPCIS. It translates the entity based data from Orion context broker to EPCIS event. Moreover, enables traceability by capturing state change in FIWARE context broker in the form of EPCIS Event. 
+FIWARE - EPCIS mediation gateway is developed to solve the interoperability between NGSI and EPCIS. It translates the entity based data from Orion context broker to EPCIS event. Moreover, enables traceability by capturing state change in FIWARE context broker in the form of EPCIS Event.
 
 ## Install
 A jar file is included. To run the mediation gateway the following command can be used. 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 This project is part of [FIWARE](https://www.fiware.org/). For more information check the FIWARE Catalogue entry for
 [Third Party Tools](https://github.com/Fiware/catalogue/tree/master/third-party).
 
-| :books: [Documentation](https://fiware-epcis-gateway.io) |
-| -------------------------------------------------------- |
+| :books: [Documentation](https://fiware-epcis-gateway.readthedocs.io) |
+| -------------------------------------------------------------------- |
 
 ## Contents
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 # Oliot-MG (FIWARE EPCIS Mediation Gateway)
 
+[![FIWARE Third Party](https://nexus.lab.fiware.org/static/badges/chapters/third-party.svg)](https://www.fiware.org/developers/catalogue/)
+
 Oliot-MG is a mediation gateway which translates information from NGSI based IoT
 platform to EPCIS based IoT platform. This enables capturing state change in
 FIWARE context broker in the form of EPCIS Event.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,14 @@
 
 site_name: EPCIS Mediation Gateway
-
+site_description: A mediation gateway which translates information from NGSI based IoT platform to EPCIS based IoT platform
+docs_dir: docs
+site_dir: html
+edit_uri: edit/master/docs/
+markdown_extensions: [toc,fenced_code]
+use_directory_urls: false
 repo_url: https://github.com/yalewkidane/FIWARE_EPCIS_Mediation_Gateway
 repo_name: GitHub
+site_url: https://fiware-epcis-gateway.readthedocs.io
 
 pages:
     -  Home: index.md
@@ -11,3 +17,4 @@ pages:
     - 'Appendix' : 'appendix.md'
 
 theme: readthedocs
+extra_css: ["https://www.fiware.org/style/fiware_readthedocs.css", "https://www.fiware.org/style/fiware_readthedocs_iot.css"]


### PR DESCRIPTION
After the TSC meeting this morning, EPCIS Gateway was formally accepted as a new FIWARE Generic Enabler.

This PR adds:

- Standard FIWARE Badging
- FIWARE CSS styling for ReadTheDocs
- Links to the FIWARE Catalogue.