### PR TITLE
Switch to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  lint-dockerfile:
+    name: Lint Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Run Hadolint Dockerfile Linter
+        uses: burdzwastaken/hadolint-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HADOLINT_ACTION_DOCKERFILE_FOLDER: .
+  unit-test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Use Java 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: 'Unit Tests with Java 8'
+        run: |
+          mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+          mvn test -B
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,19 @@
 FROM openjdk:11
-ADD target/fiware_oiliot_mediation-1.0.0.jar fiware_oiliot_mediation-1.0.0.jar
+ARG GITHUB_ACCOUNT=yalewkidane
+ARG GITHUB_REPOSITORY=FIWARE_EPCIS_Mediation_Gateway
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY target/fiware_oiliot_mediation-1.0.0.jar fiware_oiliot_mediation-1.0.0.jar
 EXPOSE 8081
 ENTRYPOINT ["java", "-jar", "fiware_oiliot_mediation-1.0.0.jar"] 
+
+LABEL "maintainer"="KAIST Oliot-MG"
+LABEL "org.opencontainers.image.authors"="yalewkidane"
+LABEL "org.opencontainers.image.documentation"="https://fiware-epcis-gateway.readthedocs.io/"
+LABEL "org.opencontainers.image.vendor"="KAIST"
+LABEL "org.opencontainers.image.licenses"="Apache-2.0"
+LABEL "org.opencontainers.image.title"="FIWARE EPCIS Mediation Gateway"
+LABEL "org.opencontainers.image.description"="Oliot-MG is a mediation gateway which translates information from NGSI based IoT platform to EPCIS based IoT platform. This enables capturing state change in FIWARE context broker in the form of EPCIS Event."
+LABEL "org.opencontainers.image.source"="https://github.com/${GITHUB_ACCOUNT}/${GITHUB_REPOSITORY}"
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![License: Apache](https://img.shields.io/github/license/yalewkidane/FIWARE_EPCIS_Mediation_Gateway.svg)](https://opensource.org/licenses/Apache-2.0)
 [![SOF support badge](https://nexus.lab.fiware.org/repository/raw/public/badges/stackoverflow/fiware.svg)](http://stackoverflow.com/questions/tagged/fiware)
 <br/>
+[![CI](https://github.com/yalewkidane/FIWARE_EPCIS_Mediation_Gateway/workflows/CI/badge.svg)](https://github.com/yalewkidane/FIWARE_EPCIS_Mediation_Gateway/actions?query=workflow%3ACI)
 [![Documentation badge](https://img.shields.io/readthedocs/fiware-epcis-gateway.svg)](https://fiware-epcis-gateway.readthedocs.io/en/latest/?badge=latest)
 ![Status](https://nexus.lab.fiware.org/static/badges/statuses/incubating.svg)
 


### PR DESCRIPTION
As I'm sure you are aware from the TSC minutes, it appears that Travis is transitioning towards a paid pricing model. It would be opportune for active FOSS Projects to migrate to use the integrated GitHub Actions. It looks like each GitHub account is safe until January, but then travis-ci.org goes read-only then the 100000 credits start counting down. There is no clarity over if/how to obtain more credits, and indeed if they can be obtained in a timely manner.

#### Background links

https://www.jeffgeerling.com/blog/2020/travis-cis-new-pricing-plan-threw-wrench-my-open-source-works
https://www.reddit.com/r/programming/comments/jou1k9/travis_cis_new_pricing_plan_threw_a_wrench_in_my/
https://www.reddit.com/r/haskell/comments/jvbs49/psa_maintainers_should_think_about_migrating_off/
https://www.reddit.com/r/programming/comments/jmwj9m/the_travis_ci_blog_the_new_pricing_model_for/

This PR sets up the equivalent GitHub Action CI to the old Travis Yaml and lints the Dockerfile